### PR TITLE
Searching for active nic name instead of using hard-coded nic name.

### DIFF
--- a/consul/consul-client.sh
+++ b/consul/consul-client.sh
@@ -4,7 +4,7 @@ export DEBIAN_FRONTEND=noninteractive
 
 apt-get -y install gawk
 
-ipaddr=$(ip addr show dev enp0s8 | awk 'match($0, /inet ([0-9.]*)\/24/, m) { print m[1] }')
+ipaddr=$(ifconfig | grep enp | awk '{print $1}' | xargs ip addr show dev | awk 'match($0, /inet ([0-9.]*)\/24/, m) { print m[1] }')
 
 #
 # Install Consul agent

--- a/consul/consul-client.sh
+++ b/consul/consul-client.sh
@@ -4,7 +4,7 @@ export DEBIAN_FRONTEND=noninteractive
 
 apt-get -y install gawk
 
-ipaddr=$(ifconfig | grep enp | awk '{print $1}' | xargs ip addr show dev | awk 'match($0, /inet ([0-9.]*)\/24/, m) { print m[1] }')
+ipaddr=$(ifconfig | grep -B1 "10.13" | head -n1 | awk '{print $1}' | xargs ip addr show dev | awk 'match($0, /inet ([0-9.]*)\/24/, m) { print m[1] }')
 
 #
 # Install Consul agent


### PR DESCRIPTION
This addresses the  blank bind_addr situation in client.json when the nic name is not what the script expected.